### PR TITLE
Add minimal API and update tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker Build Test
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./addons/sterling_os/Dockerfile
+          push: false

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv/
 __pycache__/
 *.pyc
 .env
+secrets.yaml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Sterling Home Assistant Project
+
+This repository contains a minimal Home Assistant add-on named **Sterling OS**. The add-on runs a simple Flask application and is packaged as a Docker image.
+
+## 🔐 Image Authentication
+
+To pull the pre-built Docker image hosted on GitHub Packages, you may need to authenticate using a GitHub Personal Access Token. See the [GitHub Packages documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry) for instructions.
+
+## 🛠 Installation in Home Assistant
+
+1. In Home Assistant UI, go to **Settings > Add-ons > Add-on Store**
+2. Click the top-right \u22ee menu and choose **Repositories**
+3. Add this URL: `https://github.com/jdorato376/sterling_ha_project`
+4. Locate **Sterling OS** in the store list and click **Install**

--- a/addons/sterling_os/Dockerfile
+++ b/addons/sterling_os/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY . .
+RUN pip install -r requirements.txt
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/addons/sterling_os/assist_integration.yaml
+++ b/addons/sterling_os/assist_integration.yaml
@@ -1,0 +1,1 @@
+# Home Assistant Assist routing configuration (placeholder)

--- a/addons/sterling_os/config.json
+++ b/addons/sterling_os/config.json
@@ -1,0 +1,16 @@
+{
+        "name": "Sterling OS",
+        "version": "1.0.0",
+        "slug": "sterling_os",
+        "description": "Sterling: Executive AI Assistant Add-on with Gemini & Ollama Routing",
+        "startup": "application",
+        "boot": "auto",
+        "hassio_api": true,
+        "homeassistant_api": true,
+        "host_network": true,
+        "privileged": [],
+        "arch": ["aarch64", "amd64", "armv7"],
+        "options": {},
+        "schema": {},
+        "image": "ghcr.io/jdorato376/sterling_os:1.0.0"
+    }

--- a/addons/sterling_os/entrypoint.sh
+++ b/addons/sterling_os/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 main.py

--- a/addons/sterling_os/lovelace_chatbox.yaml
+++ b/addons/sterling_os/lovelace_chatbox.yaml
@@ -1,0 +1,1 @@
+# Lovelace UI configuration (placeholder)

--- a/addons/sterling_os/main.py
+++ b/addons/sterling_os/main.py
@@ -1,0 +1,30 @@
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+
+
+@app.route("/sterling/health", methods=["GET"])
+def health_check():
+    """Simple health check endpoint."""
+    return jsonify({"status": "ok"})
+
+
+@app.route("/sterling/assistant", methods=["POST"])
+def sterling_assistant():
+    """Minimal placeholder assistant route."""
+    _ = request.get_json(force=True)
+    return jsonify({"response": "Assistant response placeholder"})
+
+
+@app.route("/etsy/orders", methods=["GET"])
+def etsy_orders():
+    """Return an empty list of orders as a stub."""
+    return jsonify({"results": []})
+
+
+if __name__ == "__main__":
+    print("Sterling OS Add-on Running")
+    try:
+        app.run(host="0.0.0.0", port=5000)
+    except KeyboardInterrupt:
+        print("Sterling OS container stopped.")

--- a/addons/sterling_os/requirements.txt
+++ b/addons/sterling_os/requirements.txt
@@ -1,0 +1,5 @@
+flask
+twilio
+openai
+requests
+ollama

--- a/repository.json
+++ b/repository.json
@@ -1,0 +1,5 @@
+{
+  "name": "Sterling OS Add-on Repository",
+  "url": "https://github.com/jdorato376/sterling_ha_project"
+}
+

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,24 +1,32 @@
-from dotenv import load_dotenv
+import importlib.util
 import os
-import requests
+import pytest
 
-load_dotenv()
+# Load the main module without requiring package installation
+module_path = os.path.join(os.path.dirname(__file__), '..', 'addons', 'sterling_os', 'main.py')
+spec = importlib.util.spec_from_file_location('main', module_path)
+main = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(main)
+app = main.app
 
-BASE_URL = "http://localhost:5000"
-HEADERS = {"FLASK_API": os.getenv("FLASK_API")}
+@pytest.fixture
 
-def test_health_check():
-    res = requests.get(f"{BASE_URL}/sterling/health")
+def client():
+    with app.test_client() as client:
+        yield client
+
+def test_health_check(client):
+    res = client.get('/sterling/health')
     assert res.status_code == 200
-    assert "status" in res.json()
+    assert 'status' in res.get_json()
 
-def test_sterling_assistant():
-    payload = {"query": "What is my schedule?", "context": "general"}
-    res = requests.post(f"{BASE_URL}/sterling/assistant", headers=HEADERS, json=payload)
+def test_sterling_assistant(client):
+    payload = {'query': 'What is my schedule?', 'context': 'general'}
+    res = client.post('/sterling/assistant', json=payload)
     assert res.status_code == 200
-    assert "response" in res.json()
+    assert 'response' in res.get_json()
 
-def test_etsy_orders():
-    res = requests.get(f"{BASE_URL}/etsy/orders", headers=HEADERS)
+def test_etsy_orders(client):
+    res = client.get('/etsy/orders')
     assert res.status_code == 200
-    assert "results" in res.json()
+    assert 'results' in res.get_json()


### PR DESCRIPTION
## Summary
- implement simple Flask server in `main.py`
- add supported architecture list to add-on `config.json`
- refactor tests to use Flask test client
- add CI workflow for Docker build
- document image authentication
- align Docker image tag and drop privileges
- make entrypoint executable in Docker build
- add Home Assistant install instructions and repository metadata

## Testing
- `pip install -r requirements.txt`
- `pip install -r addons/sterling_os/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870175effe0832b8cc2893f793b7cdc