### PR TITLE
Expand JSONStore fault tolerance

### DIFF
--- a/json_store.py
+++ b/json_store.py
@@ -6,6 +6,16 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict
 import json
+import os
+import shutil
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class JSONStoreError(Exception):
+    """Raised when persisting data fails."""
+
 
 
 @dataclass(slots=True)
@@ -17,16 +27,35 @@ class JSONStore:
 
     def read(self) -> Dict[str, Any]:
         """Load JSON data from ``path`` or return ``default`` if invalid."""
-        if self.path.exists():
-            try:
-                with self.path.open() as f:
-                    return json.load(f)
-            except json.JSONDecodeError:
-                return self.default.copy()
-        return self.default.copy()
+        if not self.path.exists():
+            return self.default.copy()
+        try:
+            with self.path.open() as f:
+                content = f.read().strip()
+                if not content:
+                    return self.default.copy()
+                return json.loads(content)
+        except (json.JSONDecodeError, OSError, PermissionError):
+            return self.default.copy()
 
     def write(self, data: Dict[str, Any]) -> None:
         """Write JSON data to ``path`` with indentation."""
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        with self.path.open("w") as f:
-            json.dump(data, f, indent=2)
+        tmp_path = self.path.with_suffix(self.path.suffix + ".tmp")
+        try:
+            with tmp_path.open("w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+            try:
+                os.replace(tmp_path, self.path)
+            except OSError:
+                try:
+                    shutil.move(tmp_path, self.path)
+                except Exception as exc:
+                    logger.exception("Atomic rename failed")
+                    raise JSONStoreError(f"Failed to write {self.path}") from exc
+        except (OSError, PermissionError) as exc:
+            logger.exception("Write error")
+            raise JSONStoreError(f"Failed to write {self.path}") from exc
+        finally:
+            if tmp_path.exists():
+                tmp_path.unlink(missing_ok=True)

--- a/runtime_memory.schema.json
+++ b/runtime_memory.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Sterling Runtime Memory",
+  "type": "object",
+  "properties": {
+    "monitor_frequency_sec": {"type": "integer", "minimum": 0, "default": 30},
+    "test_layer": {"type": "boolean", "default": false},
+    "log_heartbeat": {"type": "boolean", "default": false},
+    "last_success": {"type": "boolean", "default": true},
+    "fallback_triggered": {"type": "boolean", "default": false},
+    "agent_trace": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "timestamp": {"type": "string", "format": "date-time"},
+          "agent": {"type": "string"},
+          "query": {"type": "string"},
+          "success": {"type": "boolean"}
+        },
+        "required": ["timestamp", "agent", "query", "success"],
+        "additionalProperties": false
+      },
+      "default": []
+    },
+    "route_logs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "timestamp": {"type": "string", "format": "date-time"},
+          "query": {"type": "string"},
+          "agent": {"type": "string"},
+          "success": {"type": "boolean"},
+          "fallback": {"type": "boolean"}
+        },
+        "required": ["timestamp", "query", "agent", "success", "fallback"],
+        "additionalProperties": false
+      },
+      "default": []
+    },
+    "escalation_path": {
+      "type": "array",
+      "items": {"type": "string"},
+      "default": []
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_json_store.py
+++ b/tests/test_json_store.py
@@ -1,0 +1,110 @@
+import json
+import os
+import shutil
+from pathlib import Path
+import pytest
+from json_store import JSONStore, JSONStoreError
+
+
+def test_read_missing(tmp_path):
+    store = JSONStore(tmp_path / "missing.json", default={"foo": 1})
+    assert store.read() == {"foo": 1}
+
+
+def test_read_invalid_json(tmp_path):
+    file = tmp_path / "bad.json"
+    file.write_text("{bad")
+    store = JSONStore(file, default={"bar": 2})
+    assert store.read() == {"bar": 2}
+
+
+def test_read_permission_error(tmp_path, monkeypatch):
+    file = tmp_path / "perm.json"
+    file.write_text("{}")
+    store = JSONStore(file, default={})
+
+    def raiser(*args, **kwargs):
+        raise PermissionError
+
+    monkeypatch.setattr(Path, "open", raiser)
+    assert store.read() == {}
+
+
+def test_write_atomic(tmp_path, monkeypatch):
+    file = tmp_path / "data.json"
+    store = JSONStore(file, default={})
+    called = {}
+
+    real_replace = os.replace
+
+    def fake_replace(src, dst):
+        called["src"] = src
+        called["dst"] = dst
+        real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", fake_replace)
+
+    store.write({"x": 1})
+    assert json.loads(file.read_text()) == {"x": 1}
+    assert Path(called.get("dst")) == file
+
+
+def test_read_empty_file(tmp_path):
+    file = tmp_path / "empty.json"
+    file.write_text("")
+    store = JSONStore(file, default={"v": 3})
+    assert store.read() == {"v": 3}
+
+
+def test_write_permission_error(tmp_path, monkeypatch):
+    file = tmp_path / "data.json"
+    store = JSONStore(file, default={})
+
+    def raiser(*args, **kwargs):
+        raise PermissionError
+
+    monkeypatch.setattr(Path, "open", raiser)
+    with pytest.raises(JSONStoreError):
+        store.write({"a": 1})
+
+
+def test_atomic_write_cleanup(tmp_path, monkeypatch):
+    file = tmp_path / "data.json"
+    store = JSONStore(file, default={})
+    tmp_file = file.with_suffix(".json.tmp")
+
+    def bad_replace(src, dst):
+        raise OSError("boom")
+
+    monkeypatch.setattr(os, "replace", bad_replace)
+
+    def bad_move(src, dst):
+        raise OSError("move fail")
+
+    monkeypatch.setattr(shutil, "move", bad_move)
+
+    with pytest.raises(JSONStoreError):
+        store.write({"a": 1})
+    assert not tmp_file.exists()
+
+
+def test_rename_fallback(tmp_path, monkeypatch):
+    file = tmp_path / "data.json"
+    store = JSONStore(file, default={})
+    moved = {}
+
+    def bad_replace(src, dst):
+        raise OSError("replace fail")
+
+    real_move = shutil.move
+
+    def good_move(src, dst):
+        moved["done"] = True
+        return real_move(src, dst)
+
+    monkeypatch.setattr(os, "replace", bad_replace)
+    monkeypatch.setattr(shutil, "move", good_move)
+
+    store.write({"b": 2})
+    assert json.loads(file.read_text()) == {"b": 2}
+    assert moved.get("done")


### PR DESCRIPTION
## Summary
- make `JSONStore` fallback to `shutil.move` if `os.replace` fails
- log write errors and rename failures
- cover rename fallback and move failure cleanup in tests
- sketch runtime memory schema for future validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68719d439e2c832bb1e6f8bcc592c3a5