### PR TITLE
Add GPT4t container option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ HOME_ASSISTANT_URL=http://localhost:8123
 HA_TOKEN=your-ha-token
 OLLAMA_MODEL=llama3
 SCENE_MAP_PATH=addons/sterling_os/scene_mapper.json
+GPT_CONTAINER=gpt4t

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.12-slim
 
+ARG GPT_CONTAINER=gpt4t
+ENV GPT_CONTAINER=$GPT_CONTAINER
+
 # Set working directory
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,16 @@ cards:
     card:
       type: markdown
       content: >
-        {{ states('sensor.sterling_response') or "Awaiting input..." }}
+{{ states('sensor.sterling_response') or "Awaiting input..." }}
 ```
+
+### Quick Add-on Bundle
+
+For a ready-to-run setup, unpack `sterling_ha_addon_bundle.zip` in this
+repository. The archive provides the Sterling add-on folder along with
+Home Assistant YAML examples, including the Lovelace chat card. Copy the
+`sterling_ha_addon` directory to your `/addons` folder and import the
+files under `homeassistant/` into your configuration.
 
 To send chat prompts from Home Assistant, configure a `rest_command` that posts
 to the `/ha-chat` endpoint:
@@ -146,6 +154,7 @@ provided `.env.example` to `.env` and fill in real values when running
 - `HOME_ASSISTANT_URL` - Base URL for your Home Assistant instance. Defaults
   to `http://localhost:8123`.
 - `HA_TOKEN` - Optional token used to authorize Home Assistant chat requests.
+- `GPT_CONTAINER` - Name of the containerized LLM to use. Defaults to `gpt4t`.
 
 
 ## Autonomy Engine

--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ def info():
     return jsonify({
         "models": ["gpt-4", "gpt-4o", "gpt-3.5"],
         "fallback_chain": "gpt-4 \u2192 gpt-4o \u2192 gpt-3.5",
+        "container": os.getenv("GPT_CONTAINER", "gpt4t"),
         "commit": os.getenv("GITHUB_SHA", "local-dev"),
         "version": APP_VERSION,
     })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,16 @@ version: '3.8'
 
 services:
   sterling-api:
-    build: .
+    build:
+      context: .
+      args:
+        GPT_CONTAINER: ${GPT_CONTAINER:-gpt4t}
     ports:
       - "5000:5000"
     env_file:
       - .env
+    environment:
+      - GPT_CONTAINER=${GPT_CONTAINER}
     volumes:
       - .:/app
     restart: always


### PR DESCRIPTION
## Summary
- add configurable `GPT_CONTAINER` argument to Dockerfile
- expose container in `/info` endpoint
- pass build arg and env in docker-compose
- document new variable in README and `.env.example`
- document the included add-on bundle for quick setup

## Testing
- `pytest -q`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68732bb26490832bbc7bc0569c19a153