### PR TITLE
Add sentinel workflows and recovery script

### DIFF
--- a/.github/workflows/automate_sterling_setup.yml
+++ b/.github/workflows/automate_sterling_setup.yml
@@ -1,0 +1,62 @@
+name: Codex Sterling Autopilot
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  autopilot_codex:
+    name: "\U0001F9E0 Codex Setup & HA Deployment"
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      HA_HOST: ${{ secrets.HA_HOST }}
+      HA_TOKEN: ${{ secrets.HA_LONG_LIVED_TOKEN }}
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Set up Node (Codex CLI)
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+
+      - name: Run Codex: Integrate Sterling into HA
+        run: |
+          codex exec --full-auto "
+          You're Codex, part of Sterling GPT.
+          Automate the Home Assistant setup:
+          - Ensure /custom_components/sterling is properly deployed
+          - Update configuration.yaml to include 'sterling' component
+          - Confirm correct permissions and directory structure
+          - Add a Lovelace dashboard called 'Sterling Panel'
+          - Add a HA script named 'Run Sterling Assistant'
+          - Ensure ha core will restart cleanly
+          - Prepare for voice and text input from Assist
+          "
+
+      - name: Commit Codex Changes
+        run: |
+          git config user.name "Sterling Codex Bot"
+          git config user.email "codex@sterling.ai"
+          git commit -am "\U0001F9E0 Codex: Auto-integrated Sterling into HA" || echo "No changes"
+          git push origin main
+
+      - name: Deploy to Home Assistant
+        run: |
+          ssh -o StrictHostKeyChecking=no user@$HA_HOST "
+            cd /config &&
+            git fetch origin &&
+            git reset --hard origin/main &&
+            ha core restart
+          "
+
+      - name: Notify Success
+        run: echo "✅ Codex setup complete. HA is live with Sterling AI."

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,28 @@
+name: Sterling Canary Diagnostic
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  run_canary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Run HA Config Validation
+        run: |
+          docker run -v "${{ github.workspace }}:/config" --rm \
+          ghcr.io/home-assistant/home-assistant:stable --script check_config
+
+      - name: Run Canary Prompt via Codex CLI
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          npm install -g @openai/codex
+          codex exec --full-auto "Sterling, run full system diagnostic and confirm access to HA API, YAML, input_boolean.canary_test, and Codex write. Return status block."
+
+      - name: Report Canary Trigger
+        run: echo "✅ Sterling Canary diagnostic triggered from GitOps pipeline."

--- a/.github/workflows/haos_restore.yml
+++ b/.github/workflows/haos_restore.yml
@@ -1,0 +1,27 @@
+name: Sterling GitOps Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate config
+        run: |
+          docker run -v "${{ github.workspace }}:/config" --rm ghcr.io/home-assistant/home-assistant:stable --script check_config
+
+  deploy:
+    needs: validate
+    runs-on: ubuntu-latest
+    env:
+      HA_URL: ${{ secrets.HA_URL }}
+      HA_TOKEN: ${{ secrets.HA_LONG_LIVED_TOKEN }}
+    steps:
+      - name: Trigger Git Pull add-on
+        run: |
+          curl -X POST "https://${HA_URL}/api/services/hassio/addon_restart" -H "Authorization: Bearer ${HA_TOKEN}" -H "Content-Type: application/json" -d '{"addon":"core_git_pull"}'
+      - name: Restart HA Core
+        run: |
+          curl -X POST "https://${HA_URL}/api/services/homeassistant/restart" -H "Authorization: Bearer ${HA_TOKEN}" -H "Content-Type: application/json" -d '{}'

--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -1,0 +1,46 @@
+name: Sterling Sentinel Monitor
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 * * * *'  # Hourly health check
+  workflow_dispatch:
+
+jobs:
+  sentinel_watchdog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sterling Repo
+        uses: actions/checkout@v3
+
+      - name: Validate HA Configuration (YAML)
+        run: |
+          docker run -v "${{ github.workspace }}:/config" --rm \
+          ghcr.io/home-assistant/home-assistant:stable \
+          --script check_config
+
+      - name: Canary Prompt to Sterling
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          npm install -g @openai/codex
+          codex exec --full-auto "
+          Sterling, run sentinel mode: 
+          1. Validate HA API access.
+          2. Ensure input_boolean.canary_test exists.
+          3. Toggle it to test service call.
+          4. Confirm write access to /config.
+          5. Run YAML syntax check.
+          6. Report and fix drift if found.
+          7. Return full system diagnostic summary."
+
+      - name: Restart Home Assistant via API
+        env:
+          HA_TOKEN: ${{ secrets.HA_LONG_LIVED_TOKEN }}
+          HA_URL: ${{ secrets.HA_URL }}
+        run: |
+          curl -s -X POST "https://${HA_URL}/api/services/homeassistant/restart" \
+            -H "Authorization: Bearer ${HA_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{}'

--- a/.github/workflows/sentinel_trigger.yml
+++ b/.github/workflows/sentinel_trigger.yml
@@ -1,0 +1,14 @@
+name: Trigger Sterling Sentinel Webhook
+
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger_webhook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger HA Sentinel Mode via Webhook
+        run: |
+          curl -X POST "https://${{ secrets.HA_URL }}/api/webhook/sterling_gitops_sync" \
+            -H "Authorization: Bearer ${{ secrets.HA_LONG_LIVED_TOKEN }}" \
+            -H "Content-Type: application/json"

--- a/README.md
+++ b/README.md
@@ -255,6 +255,84 @@ curl --fail http://localhost:5000/status
 
 You should receive a JSON response indicating the service is running.
 
+## Canary Diagnostic Workflow
+
+The `canary.yml` GitHub Actions workflow validates Home Assistant configuration and runs a Codex-powered system diagnostic. Trigger it manually from the Actions tab or when you push to `main` to confirm API access and write permissions remain intact.
+
+## Sentinel Monitor Workflow
+
+`sentinel.yml` provides an hourly watchdog. It validates configuration, runs a full diagnostic via Codex, and restarts Home Assistant through the API. Enable it to keep Sterling fully autonomous and self-healing.
+
+## Local Sentinel Test Script
+
+Run `./start.sh` to execute a recovery-enabled Sentinel diagnostic. The script will restore your configuration from the repository if `/config/configuration.yaml` is missing and then perform several checks:
+
+1. Verify Home Assistant API reachability.
+2. Ensure `configuration.yaml` exists.
+3. Create `input_boolean.canary_test` if it is missing.
+4. Toggle the canary entity to confirm service calls.
+5. Validate Codex CLI write access.
+6. Run `check_config` to validate YAML syntax.
+
+The script reads `REPO_URL`, `HA_URL`, `HA_TOKEN`, `OPENAI_API_KEY`, and `CONFIG_PATH` from the environment, falling back to sensible defaults. Configure these variables before running if needed.
+
+
+## Sentinel GitOps Redeployment Webhook
+
+Use this webhook to redeploy the entire Home Assistant configuration from GitHub when called. It will pull a fresh copy of the repository and restart Home Assistant if your configuration becomes corrupted or missing.
+
+Add the automation to `automations.yaml`:
+```yaml
+- id: sterling_gitops_redeploy
+  alias: "Sterling Sentinel Webhook — Redeploy Config"
+  mode: single
+  trigger:
+    platform: webhook
+    webhook_id: sterling_gitops_sync
+  action:
+    - service: hassio.addon_restart
+      data:
+        addon: core_ssh
+    - delay: "00:00:05"
+    - service: shell_command.sterling_gitops_sync
+```
+
+Define the shell command in `configuration.yaml`:
+```yaml
+shell_command:
+  sterling_gitops_sync: >
+    bash -c "cd /config &&
+    ha core stop &&
+    rm -rf .git old_* backup_* custom_components/sterling* sterling_ha_project &&
+    git clone https://github.com/jdorato376/sterling_ha_project.git &&
+    mkdir -p custom_components &&
+    cp -r sterling_ha_project/homeassistant_config/custom_components/sterling custom_components/sterling &&
+    cp -n sterling_ha_project/homeassistant_config/configuration.yaml /config/ &&
+    cp -n sterling_ha_project/homeassistant_config/secrets.yaml /config/ &&
+    cp -n sterling_ha_project/homeassistant_config/automations.yaml /config/ &&
+    cp -n sterling_ha_project/homeassistant_config/scripts.yaml /config/ &&
+    chmod -R 755 custom_components/sterling &&
+    ha core start"
+```
+
+Trigger the webhook with `.github/workflows/sentinel_trigger.yml`:
+```yaml
+name: Trigger Sterling Sentinel Webhook
+
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger_webhook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger HA Sentinel Mode via Webhook
+        run: |
+          curl -X POST https://${{ secrets.HA_URL }}/api/webhook/sterling_gitops_sync \
+            -H "Authorization: Bearer ${{ secrets.HA_LONG_LIVED_TOKEN }}" \
+            -H "Content-Type: application/json"
+```
+Ensure `HA_URL` and `HA_LONG_LIVED_TOKEN` secrets are set in your GitHub repository.
 
 ## Roadmap Documents
 - [Phase 3 AI Autonomy Roadmap](docs/phase3_ai_autonomy_roadmap.md)

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sterling HA Recovery and Sentinel Test Script
+# Restores repo if wiped and validates basic functionality
+
+REPO_URL="${REPO_URL:-https://github.com/jdorato376/sterling_ha_project.git}"
+HA_URL="${HA_URL:-https://your-ha-domain-or-ip}"
+HA_TOKEN="${HA_TOKEN:-your_long_lived_token}"
+OPENAI_API_KEY="${OPENAI_API_KEY:-your_codex_key}"
+CONFIG_PATH="${CONFIG_PATH:-/config}"
+
+# Restore repository if configuration is missing
+if [ ! -f "$CONFIG_PATH/configuration.yaml" ]; then
+  echo "📦 Restoring configuration from $REPO_URL"
+  rm -rf "${CONFIG_PATH:?}"/*
+  git clone "$REPO_URL" "$CONFIG_PATH"
+fi
+
+cd "$CONFIG_PATH"
+
+echo "🔍 Sterling Sentinel Test Starting..."
+
+# Step 1: Ping HA API
+echo "🔧 Checking HA API reachability..."
+API_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $HA_TOKEN" \
+  "$HA_URL/api/")
+if [ "$API_STATUS" = "200" ]; then
+  echo "✅ HA API reachable"
+else
+  echo "❌ HA API unreachable ($API_STATUS)"
+fi
+
+# Step 2: Check configuration.yaml
+if [ -f "$CONFIG_PATH/configuration.yaml" ]; then
+  echo "✅ configuration.yaml exists"
+else
+  echo "❌ Missing configuration.yaml" && exit 1
+fi
+
+# Step 3: Canary entity check
+ENTITY_CHECK=$(curl -s -H "Authorization: Bearer $HA_TOKEN" \
+  "$HA_URL/api/states/input_boolean.canary_test" || true)
+if [[ $ENTITY_CHECK == *"state"* ]]; then
+  echo "✅ Canary entity found"
+else
+  echo "⚠️ Canary entity missing; adding to configuration.yaml"
+  cat >> configuration.yaml <<'CANARY'
+input_boolean:
+  canary_test:
+    name: Canary Test Toggle
+    initial: off
+    icon: mdi:shield-check
+CANARY
+fi
+
+# Step 4: Toggle canary entity
+curl -s -X POST "$HA_URL/api/services/input_boolean/toggle" \
+  -H "Authorization: Bearer $HA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"entity_id": "input_boolean.canary_test"}' >/dev/null && \
+  echo "✅ Toggle successful" || echo "❌ Toggle failed"
+
+# Step 5: Test Codex write access
+if echo "$OPENAI_API_KEY" | grep -q "sk-"; then
+  npm install -g @openai/codex >/dev/null
+  codex exec --full-auto "Append # Codex test pass to configuration.yaml" >/dev/null
+  grep -q "# Codex test pass" configuration.yaml && \
+  echo "✅ Codex write succeeded" || echo "❌ Codex write failed"
+else
+  echo "❌ Invalid Codex key format" && exit 1
+fi
+
+# Step 6: Validate config syntax
+echo "🧪 Validating Home Assistant config..."
+docker run -v "$CONFIG_PATH:/config" --rm \
+  ghcr.io/home-assistant/home-assistant:stable --script check_config >/dev/null && \
+  echo "✅ YAML validation passed" || echo "❌ YAML validation failed"
+
+echo "✅ Sentinel test script completed."


### PR DESCRIPTION
## Summary
- automate Sterling setup via Codex in GitHub Actions
- add canary diagnostic workflow
- add full HAOS restore workflow
- run hourly sentinel monitor
- add webhook trigger workflow for redeploy
- document new workflows and local recovery script
- clarify sentinel redeploy description

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873c63b2b54832b8bb31105e198f27f