### PR TITLE
Fix YAML syntax in automate_sterling_setup workflow

### DIFF
--- a/.github/workflows/automate_sterling_setup.yml
+++ b/.github/workflows/automate_sterling_setup.yml
@@ -21,7 +21,7 @@ jobs:
       - name: \ud83d\udd0d Validate HA Configs
         run: |
           echo "\ud83d\udea8 Canary Lint Check Initiated"
-          FILES=("configuration.yaml" "automations.yaml" "scripts.yaml")
+          FILES=("configuration.yaml" "automations.yaml" "scripts.yaml" "secrets.yaml" "intent_script.yaml")
 
           ERRORS=0
           for file in "${FILES[@]}"; do
@@ -29,14 +29,14 @@ jobs:
               echo "\ud83e\uddca Linting $file..."
               yamllint "$file" || ERRORS=$((ERRORS+1))
             else
-              echo "\u26a0\ufe0f Skipped missing $file"
+              echo "\u26a0\ufe0f Skipping missing file: $file"
             fi
           done
 
           if [ "$ERRORS" -gt 0 ]; then
-            echo "\u274c Lint errors detected"
+            echo "\u274c Lint errors detected in $ERRORS file(s)"
             exit 1
           else
-            echo "\u2705 All configs pass lint"
+            echo "\u2705 Canary Passed: All YAML files clean"
           fi
 


### PR DESCRIPTION
## Summary
- fix YAML error by replacing the workflow file

## Testing
- `pytest -k canary -q`
- `yamllint .github/workflows/automate_sterling_setup.yml`

------
https://chatgpt.com/codex/tasks/task_e_68745f6d4224832b918019e335854b69