### PR TITLE
Potential fix for code scanning alert no. 18: Information exposure through an exception

### DIFF
--- a/ai_router/main.py
+++ b/ai_router/main.py
@@ -23,7 +23,7 @@ def handle_routing():
         return jsonify(result), 200
     except Exception as e:  # pragma: no cover - runtime safeguard
         logging.exception("Routing error")
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 
 @app.route("/health", methods=["GET"])


### PR DESCRIPTION
Potential fix for [https://github.com/jdorato376/sterling_ha_project/security/code-scanning/18](https://github.com/jdorato376/sterling_ha_project/security/code-scanning/18)

To fix this problem, the application should avoid returning the exception message (or stack trace) to the user. Instead, it should return a generic error message such as "An internal error has occurred." The exception (including stack trace and message) should continue to be logged server-side for debugging purposes. The only change required is to modify the error response on line 26 in `ai_router/main.py` to use a generic message, while keeping the server-side logging as-is.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
