### PR TITLE
Potential fix for code scanning alert no. 15: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,7 +134,8 @@ def webhook_rebuild():
         subprocess.call(["pip", "install", "--no-cache-dir", "-r", "requirements.txt"])
         return jsonify(status="updated")
     except Exception as e:
-        return jsonify(status="error", detail=str(e)), 500
+        app.logger.error(f"Error during rebuild webhook: {str(e)}")
+        return jsonify(status="error", detail="An internal error occurred."), 500
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
Potential fix for [https://github.com/jdorato376/sterling_ha_project/security/code-scanning/15](https://github.com/jdorato376/sterling_ha_project/security/code-scanning/15)

The best way to fix this issue is to log the detailed error message on the server for debugging purposes and return a generic error message to the user. This approach ensures that sensitive information is not exposed to external users while retaining the necessary information for debugging.

To implement the fix:
1. Replace `str(e)` on line 137 with a generic error response.
2. Log the full error message (`e` or `traceback.format_exc()`) within the server for internal use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
