### PR TITLE
Potential fix for code scanning alert no. 14: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -65,7 +65,9 @@ def version():
     try:
         commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
     except Exception as e:
-        commit_hash = f"Error: {str(e)}"
+        import logging
+        logging.error("Failed to retrieve commit hash", exc_info=e)
+        commit_hash = "unknown"
     return jsonify({
         "commit_hash": commit_hash,
         "branch": os.getenv("GIT_BRANCH", "unknown"),


### PR DESCRIPTION
Potential fix for [https://github.com/jdorato376/sterling_ha_project/security/code-scanning/14](https://github.com/jdorato376/sterling_ha_project/security/code-scanning/14)

To address the issue, we will modify the code to ensure that sensitive stack trace information is not exposed to external users. Instead of including the exception details in the JSON response, we will log the full stack trace on the server for debugging purposes while returning a generic error message to the client. This approach aligns with best practices for error handling and ensures sensitive information remains protected.

**Steps to fix:**
1. Replace the code on line 68, which currently uses `str(e)` to expose exception details, with a generic error message like "unknown".
2. Log the exception details (stack trace) to the server for debugging using Python's `logging` module.
3. Add an import statement for `logging` if it is not yet present in the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
